### PR TITLE
Add .NET 5 & .NET 3.1 as new targets

### DIFF
--- a/src/CSharpSyntaxValidator.csproj
+++ b/src/CSharpSyntaxValidator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <VersionPrefix>1.4.0</VersionPrefix>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>csval</ToolCommandName>

--- a/src/NDesk.Options.cs
+++ b/src/NDesk.Options.cs
@@ -490,7 +490,6 @@ namespace Mono.Options
 			get {return this.option;}
 		}
 
-		[SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
 		public override void GetObjectData (SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData (info, context);


### PR DESCRIPTION
This PR adds .NET 5 & .NET 3.1 as new targets. It also removes applications of [`SecurityPermission` attribute since it is now obsolete](https://docs.microsoft.com/en-us/dotnet/core/compatibility/syslib0003).
