### PR TITLE
Update to latest Roslyn release (3.8.0)

### DIFF
--- a/src/CSharpSyntaxValidator.csproj
+++ b/src/CSharpSyntaxValidator.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates Roslyn to [release 3.8.0](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp/3.8.0) that includes the final C# 9 bits.
