### PR TITLE
Rewrite program as top-level statements

### DIFF
--- a/src/CSharpSyntaxValidator.csproj
+++ b/src/CSharpSyntaxValidator.csproj
@@ -32,7 +32,7 @@
     <None Remove="Help.txt" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Help.txt" />
+    <EmbeddedResource Include="Help.txt" LogicalName="Help.txt" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR re-writes the program using top-level statements.

This is a simple program. It doesn't really need a namespace (arguably didn't need one before) or a housing `Program` class so code can be de-nested two levels.