### PR TITLE
Use full `net5.0` TFM moniker

### DIFF
--- a/src/CSharpSyntaxValidator.csproj
+++ b/src/CSharpSyntaxValidator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <VersionPrefix>1.4.0</VersionPrefix>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>csval</ToolCommandName>


### PR DESCRIPTION
Otherwise, building with SDK 5.0.400 produces the error:

    error NETSDK1005: Assets file 'A:\CSharpSyntaxValidator\src\obj\project.assets.json' doesn't have a target for 'net5.0'. Ensure that restore has run and that you have included 'net5.0' in the TargetFrameworks for your project.