### PR TITLE
Fix exit code propagation in batch scripts

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,11 +1,13 @@
 @echo off
+setlocal
 pushd "%~dp0"
 call :main %*
+set EXIT_CODE=%ERRORLEVEL%
 popd
-goto :EOF
+exit /b %EXIT_CODE%
 
 :main
     dotnet restore ^
  && dotnet build --no-restore -c Debug ^
  && dotnet build --no-restore -c Release
-goto :EOF
+exit /b %ERRORLEVEL%

--- a/pack.cmd
+++ b/pack.cmd
@@ -1,12 +1,14 @@
 @echo off
+setlocal
 pushd "%~dp0"
 call :main %*
+set EXIT_CODE=%ERRORLEVEL%
 popd
-goto :EOF
+exit /b %EXIT_CODE%
 
 :main
 setlocal
 set VERSION_SUFFIX=
 if not "%~1"=="" set VERSION_SUFFIX=--version-suffix %~1
 call build && dotnet pack --no-build -c Release %VERSION_SUFFIX% src
-goto :EOF
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
Build for PR #14 (see [attached log](https://github.com/atifaziz/CSharpSyntaxValidator/files/6986454/log.txt)) should have failed, but instead it succeeded due to the exit code or `%ERRORLEVEL%` propagation not working properly through the Windows batch scripts. This PR fixes the exit code propagation.

---
📎 [`log.txt`](https://github.com/atifaziz/CSharpSyntaxValidator/files/6986454/log.txt)
