### PR TITLE
Update ThisAssemply.AssemblyInfo to 1.0.8

### DIFF
--- a/src/CSharpSyntaxValidator.csproj
+++ b/src/CSharpSyntaxValidator.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.0.0" />
+    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pulls in bug fix devlooped/ThisAssembly#50 that addresses the following build error:

    ThisAssembly.Prerequisites.targets(4,5): error : ThisAssembly requires MSBuild 16.8+ or .NET SDK 5.0+.